### PR TITLE
Enhance documentation: Use 'this' return type for chainable methods

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -4,7 +4,7 @@ const {Transform} = require("./transform")
 const {AddMarkStep, RemoveMarkStep} = require("./mark_step")
 const {ReplaceStep} = require("./replace_step")
 
-// :: (number, number, Mark) → Transform
+// :: (number, number, Mark) → this
 // Add the given mark to the inline content between `from` and `to`.
 Transform.prototype.addMark = function(from, to, mark) {
   let removed = [], added = [], removing = null, adding = null
@@ -36,7 +36,7 @@ Transform.prototype.addMark = function(from, to, mark) {
   return this
 }
 
-// :: (number, number, ?union<Mark, MarkType>) → Transform
+// :: (number, number, ?union<Mark, MarkType>) → this
 // Remove the given mark, or all marks of the given type, from inline
 // nodes between `from` and `to`.
 Transform.prototype.removeMark = function(from, to, mark = null) {
@@ -74,7 +74,7 @@ Transform.prototype.removeMark = function(from, to, mark = null) {
   return this
 }
 
-// :: (number, number) → Transform
+// :: (number, number) → this
 // Remove all marks and non-text inline nodes from the given range.
 Transform.prototype.clearMarkup = function(from, to) {
   let delSteps = [] // Must be accumulated and applied in inverse order

--- a/src/replace.js
+++ b/src/replace.js
@@ -4,7 +4,7 @@ const {ReplaceStep, ReplaceAroundStep} = require("./replace_step")
 const {Transform} = require("./transform")
 const {insertPoint} = require("./structure")
 
-// :: (number, number, Slice) → Transform
+// :: (number, number, Slice) → this
 // Replace a range of the document with a given slice, using `from`,
 // `to`, and the slice's [`openStart`](#model.Slice.openStart) property
 // as hints, rather than fixed start and end points. This method may
@@ -79,7 +79,7 @@ function closeFragment(fragment, depth, oldOpen, newOpen, parent) {
   return fragment
 }
 
-// :: (number, number, Node) → Transform
+// :: (number, number, Node) → this
 // Replace the given range with a node, but use `from` and `to` as
 // hints, rather than precise positions. When from and to are the same
 // and are at the start or end of a parent node in which the given
@@ -95,7 +95,7 @@ Transform.prototype.replaceRangeWith = function(from, to, node) {
   return this.replaceRange(from, to, new Slice(Fragment.from(node), 0, 0))
 }
 
-// :: (number, number) → Transform
+// :: (number, number) → this
 // Delete the given range, expanding it to cover fully covered
 // parent nodes until a valid replace is found.
 Transform.prototype.deleteRange = function(from, to) {
@@ -133,7 +133,7 @@ function coveredDepths($from, $to) {
   return result
 }
 
-// :: (number, number) → Transform
+// :: (number, number) → this
 // Delete the content between the given positions.
 Transform.prototype.delete = function(from, to) {
   return this.replace(from, to, Slice.empty)
@@ -164,7 +164,7 @@ function replaceStep(doc, from, to = from, slice = Slice.empty) {
 }
 exports.replaceStep = replaceStep
 
-// :: (number, ?number, ?Slice) → Transform
+// :: (number, ?number, ?Slice) → this
 // Replace the part of the document between `from` and `to` with the
 // given `slice`.
 Transform.prototype.replace = function(from, to = from, slice = Slice.empty) {
@@ -173,14 +173,14 @@ Transform.prototype.replace = function(from, to = from, slice = Slice.empty) {
   return this
 }
 
-// :: (number, number, union<Fragment, Node, [Node]>) → Transform
+// :: (number, number, union<Fragment, Node, [Node]>) → this
 // Replace the given range with the given content, which may be a
 // fragment, node, or array of nodes.
 Transform.prototype.replaceWith = function(from, to, content) {
   return this.replace(from, to, new Slice(Fragment.from(content), 0, 0))
 }
 
-// :: (number, union<Fragment, Node, [Node]>) → Transform
+// :: (number, union<Fragment, Node, [Node]>) → this
 // Insert the given content at the given position.
 Transform.prototype.insert = function(pos, content) {
   return this.replaceWith(pos, pos, content)

--- a/src/structure.js
+++ b/src/structure.js
@@ -26,7 +26,7 @@ function liftTarget(range) {
 }
 exports.liftTarget = liftTarget
 
-// :: (NodeRange, number) → Transform
+// :: (NodeRange, number) → this
 // Split the content in the given range off from its parent, if there
 // is sibling content before or after it, and move it up the tree to
 // the depth specified by `target`. You'll probably want to use
@@ -99,7 +99,7 @@ function findWrappingInside(range, wrap) {
   return inside
 }
 
-// :: (NodeRange, [{type: NodeType, attrs: ?Object}]) → Transform
+// :: (NodeRange, [{type: NodeType, attrs: ?Object}]) → this
 // Wrap the given [range](#model.NodeRange) in the given set of wrappers.
 // The wrappers are assumed to be valid in this position, and should
 // probably be computed with `findWrapping`.
@@ -112,7 +112,7 @@ Transform.prototype.wrap = function(range, wrappers) {
   return this.step(new ReplaceAroundStep(start, end, start, end, new Slice(content, 0, 0), wrappers.length, true))
 }
 
-// :: (number, ?number, NodeType, ?Object) → Transform
+// :: (number, ?number, NodeType, ?Object) → this
 // Set the type of all textblocks (partly) between `from` and `to` to
 // the given node type with the given attributes.
 Transform.prototype.setBlockType = function(from, to = from, type, attrs) {
@@ -132,7 +132,7 @@ Transform.prototype.setBlockType = function(from, to = from, type, attrs) {
   return this
 }
 
-// :: (number, ?NodeType, ?Object, ?[Mark]) → Transform
+// :: (number, ?NodeType, ?Object, ?[Mark]) → this
 // Change the type and attributes of the node after `pos`.
 Transform.prototype.setNodeType = function(pos, type, attrs, marks) {
   let node = this.doc.nodeAt(pos)
@@ -172,7 +172,7 @@ function canSplit(doc, pos, depth = 1, typesAfter) {
 }
 exports.canSplit = canSplit
 
-// :: (number, ?number, ?[?{type: NodeType, attrs: ?Object}]) → Transform
+// :: (number, ?number, ?[?{type: NodeType, attrs: ?Object}]) → this
 // Split the node at the given position, and optionally, if `depth` is
 // greater than one, any number of nodes above that. By default, the
 // parts split off will inherit the node type of the original node.
@@ -227,7 +227,7 @@ function joinPoint(doc, pos, dir = -1) {
 }
 exports.joinPoint = joinPoint
 
-// :: (number, ?number, ?bool) → Transform
+// :: (number, ?number, ?bool) → this
 // Join the blocks around the given position. If depth is 2, their
 // last and first siblings are also joined, and so on.
 Transform.prototype.join = function(pos, depth = 1) {

--- a/src/transform.js
+++ b/src/transform.js
@@ -33,7 +33,7 @@ class Transform {
   // :: Node The document at the start of the transformation.
   get before() { return this.docs.length ? this.docs[0] : this.doc }
 
-  // :: (step: Step) → Transform
+  // :: (step: Step) → this
   // Apply a new step in this transformation, saving the result.
   // Throws an error when the step fails.
   step(object) {


### PR DESCRIPTION
The [polymorphic `this` type](https://www.typescriptlang.org/docs/handbook/advanced-types.html#polymorphic-this-types) makes it clear that when using these methods on an instance of a
subclass, you get the same instance of that subclass back (instead of a
possibly different instance of the parent class).