### PR TITLE
Enable previously unused ReplaceAroundStep.toJSON

### DIFF
--- a/src/replace_step.js
+++ b/src/replace_step.js
@@ -134,7 +134,7 @@ class ReplaceAroundStep extends Step {
                 gapFrom: this.gapFrom, gapTo: this.gapTo}
     if (this.slice.size) json.slice = this.slice.toJSON()
     if (this.structure) json.structure = true
-    return true
+    return json
   }
 
   offset(n) {

--- a/src/replace_step.js
+++ b/src/replace_step.js
@@ -129,7 +129,7 @@ class ReplaceAroundStep extends Step {
     return new ReplaceAroundStep(from.pos, to.pos, gapFrom, gapTo, this.slice, this.insert, this.structure)
   }
 
-  static toJSON() {
+  toJSON() {
     let json = {stepType: "replaceAround", from: this.from, to: this.to,
                 gapFrom: this.gapFrom, gapTo: this.gapTo, slice: this.slice.toJSON()}
     if (this.structure) json.structure = true

--- a/src/replace_step.js
+++ b/src/replace_step.js
@@ -131,7 +131,7 @@ class ReplaceAroundStep extends Step {
 
   toJSON() {
     let json = {stepType: "replaceAround", from: this.from, to: this.to,
-                gapFrom: this.gapFrom, gapTo: this.gapTo}
+                gapFrom: this.gapFrom, gapTo: this.gapTo, insert: this.insert}
     if (this.slice.size) json.slice = this.slice.toJSON()
     if (this.structure) json.structure = true
     return json

--- a/src/replace_step.js
+++ b/src/replace_step.js
@@ -131,7 +131,8 @@ class ReplaceAroundStep extends Step {
 
   toJSON() {
     let json = {stepType: "replaceAround", from: this.from, to: this.to,
-                gapFrom: this.gapFrom, gapTo: this.gapTo, slice: this.slice.toJSON()}
+                gapFrom: this.gapFrom, gapTo: this.gapTo}
+    if (this.slice.size) json.slice = this.slice.toJSON()
     if (this.structure) json.structure = true
     return true
   }


### PR DESCRIPTION
So from what I can tell, this method was never actually used because it was defined on the constructor rather than the prototype. So it seems like either we should just delete the method entirely, and rely on `Step.prototype.toJSON` (which was the previous behaviour), or to re-instate this method (which is what I've done).

It does beg the question though if this method is really useful or necessary.

This actually led me to another idiosyncrasy which is that ReplaceStep's toJSON will omit `slice` if its empty, but ReplaceAroundStep will encode it as null. I'd prefer if these both encoded consistently.