### PR TITLE
Make explicit the default value for `assoc`.

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -73,12 +73,12 @@ class StepMap {
   // content at (or around) this position—if `assoc` is negative, the a
   // position before the inserted content will be returned, if it is
   // positive, a position after the insertion is returned.
-  mapResult(pos, assoc) { return this._map(pos, assoc, false) }
+  mapResult(pos, assoc = 1) { return this._map(pos, assoc, false) }
 
   // :: (number, ?number) → number
   // Map the given position through this map, returning only the
   // mapped position.
-  map(pos, assoc) { return this._map(pos, assoc, true) }
+  map(pos, assoc = 1) { return this._map(pos, assoc, true) }
 
   _map(pos, assoc, simple) {
     let diff = 0, oldIndex = this.inverted ? 2 : 1, newIndex = this.inverted ? 1 : 2


### PR DESCRIPTION
I *think* the default value is 1, but it's really hard to tell from a cursory read of the code. I'm guessing it's one because the InlineType of decoration computes `assoc` as `this.spec.inclusiveStart ? -1 : 1`, and presumably the default is to *not* be inclusive start.

The goal is to make the documentation (both HTML and code) more clear here.

Presumably `Mapping#map` should be updated too. Are there other places?