### PR TITLE
fix adding a mark in addMark method when a node doesn't allow marks

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -11,7 +11,7 @@ Transform.prototype.addMark = function(from, to, mark) {
   this.doc.nodesBetween(from, to, (node, pos, parent) => {
     if (!node.isInline) return
     let marks = node.marks
-    if (!mark.isInSet(marks) && parent.type.allowsMarkType(mark.type)) {
+    if (node.type.spec.marks !== '' && !mark.isInSet(marks) && parent.type.allowsMarkType(mark.type)) {
       let start = Math.max(pos, from), end = Math.min(pos + node.nodeSize, to)
       let newSet = mark.addToSet(marks)
 


### PR DESCRIPTION
Imagine I have a node:
```
{
    inline: true,
    marks: "",
    group: "inline",
    parseDOM: [{tag: "span"}],
    toDOM: function toDOM(node) {
      return ["span", {}, 'someText']
    }
}
```
When I try to apply a mark on that node, I expect the schema to restrict that, but yet its possible.

Playground: https://github.com/eshvedai/website/commit/2bccc0e214202484c5a03c7bdaeb6859cc13fa04

This PR is my attempt to fix this issue. Let me know if its not the best place, I'll update the PR.