### PR TITLE
Fix the type definition for findWrapping

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -60,7 +60,7 @@ Transform.prototype.lift = function(range, target) {
                                          before.size - openStart, true))
 }
 
-// :: (NodeRange, NodeType, ?Object) → ?[{type: NodeType, attrs: ?Object}]
+// :: (NodeRange, NodeType, ?Object, ?NodeRange) → ?[{type: NodeType, attrs: ?Object}]
 // Try to find a valid way to wrap the content in the given range in a
 // node of the given type. May introduce extra nodes around and inside
 // the wrapper node, if necessary. Returns null if no valid wrapping


### PR DESCRIPTION
This adds a missing `?NodeRange` to the definition of the `findWrapping` method.

https://github.com/ProseMirror/prosemirror-transform/blob/b71af28276cbad08f12940247a5c922fe98b4b78/src/structure.js#L63-L68