### PR TITLE
Fix dropPoint function

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -270,13 +270,13 @@ export function dropPoint(doc, pos, slice) {
   if (!slice.content.size) return pos
   let content = slice.content
   for (let i = 0; i < slice.openStart; i++) content = content.firstChild.content
-  for (let pass = 1; pass <= (slice.openStart == 0 && slice.length ? 2 : 1); pass++) {
+  for (let pass = 1; pass <= (slice.openStart == 0 && slice.size ? 2 : 1); pass++) {
     for (let d = $pos.depth; d >= 0; d--) {
       let bias = d == $pos.depth ? 0 : $pos.pos <= ($pos.start(d + 1) + $pos.end(d + 1)) / 2 ? -1 : 1
       let insertPos = $pos.index(d) + (bias > 0 ? 1 : 0)
       if (pass == 1
           ? $pos.node(d).canReplace(insertPos, insertPos, content)
-          : $pos.node(d).contentMatchAt(insertPos).findWrapping(content.firstChild))
+          : $pos.node(d).contentMatchAt(insertPos).findWrapping(content.firstChild.type))
         return bias == 0 ? $pos.pos : bias < 0 ? $pos.before(d + 1) : $pos.after(d + 1)
     }
   }


### PR DESCRIPTION
When I was testing the new dropPoint-function I was not seeing the expected result. Upon further inspection and debugging I found which parts I need to change to make it work. 

- There is nor property `length` on a `Slice` but there is a property `size` - Here I am not 100% sure if the change I made is correct. As far as I understand you do not want to test for a wrapping, if the `slice` is empty. If that's the case, `slice.size` should work here. 
- `ContentMatch.findWrapping` takes a `NodeType` and not a `Node`
