### PR TITLE
fixing a bug in closeFragment

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -482,8 +482,11 @@ function closeFragment(fragment, depth, oldOpen, newOpen, parent) {
     let first = fragment.firstChild
     fragment = fragment.replaceChild(0, first.copy(closeFragment(first.content, depth + 1, oldOpen, newOpen, first)))
   }
-  if (depth > newOpen)
-    fragment = parent.contentMatchAt(0).fillBefore(fragment, true).append(fragment)
+  if (depth > newOpen) {
+    let filledBefore = parent.contentMatchAt(0).fillBefore(fragment, true)
+    if (filledBefore)
+      fragment = filledBefore.append(fragment)
+  }
   return fragment
 }
 


### PR DESCRIPTION
when [`fillBefore`](https://prosemirror.net/docs/ref/#model.ContentMatch.fillBefore) is called with `toEnd=true`, it won't return a fragment whose match isn't able to go to the end of the content expression. In this `closeFragment` code, we've seen a few cases where the code as it stands generates an exception. This should be a simple patch to fix this case, though unfortunately because it has come up in a production app as part of a paste, I don't have a great grasp on a test case that might be able to reproduce the conditions of the bug.