### PR TITLE
Add step ranges

### DIFF
--- a/test/test-mapping.js
+++ b/test/test-mapping.js
@@ -44,3 +44,16 @@ describe("Mapping", () => {
     testMapping(mk([2, 4, 0], [1, 0, 1], [3, 0, 4], {0: 2}), [0, 0], [1, 2], [4, 5], [6, 7], [7, 8])
   })
 })
+
+describe("StepRanges", () => {
+  it("maps new ranges", () => {
+    let stepRanges = new StepMap([5, 0, 4]).getRanges()
+    let mapping = mk([1, 0, 1], [8, 0, 4])
+    ist(!stepRanges.map(mapping).touches(5))
+    ist(stepRanges.map(mapping).touches(6))
+    ist(stepRanges.map(mapping).touches(5, 6))
+    ist(stepRanges.map(mapping).touches(14))
+    ist(stepRanges.map(mapping).touches(14, 15))
+    ist(!stepRanges.map(mapping).touches(15))
+  })
+})


### PR DESCRIPTION
Had a quick look at this on the train, if it looks like it's going in the right direction I can add proper tests / doc strings (plus revisit any logic errors) but thought it better to throw this up.

If this looks ok then instead of `prevMap` inside the history plugin, there can be `prevRanges` which can be mapped for each appended transaction and then tested on new input with `touches`.