### PR TITLE
When close child size is 0, close() returned without changing

### DIFF
--- a/src/replace.js
+++ b/src/replace.js
@@ -271,8 +271,10 @@ class Fitter {
     if (!close) return null
 
     while (this.depth > close.depth) this.closeFrontierNode()
-    if (close.fit.childCount) this.placed = addToFragment(this.placed, close.depth, close.fit)
-    $to = close.move
+    if (close.fit.childCount) {
+      this.placed = addToFragment(this.placed, close.depth, close.fit)
+      $to = close.move
+    }
     for (let d = close.depth + 1; d <= $to.depth; d++) {
       let node = $to.node(d), add = node.type.contentMatch.fillBefore(node.content, true, $to.index(d))
       this.openFrontierNode(node.type, node.attrs, add)


### PR DESCRIPTION
Related issue: https://github.com/outline/rich-markdown-editor/issues/233
 https://github.com/outline/rich-markdown-editor/pull/252/files

https://github.com/ProseMirror/prosemirror-transform/commit/3915231ad4dca4c40892173ee509d268b685e19d
After this commit(> 1.2.5), "setBlockType ()" of "prosemirror-command" has a problem.

This is a fix for the problem that Node's Wrap is not working as shown in the image.
Specifically, the line you intended to change is deleted, and the line below is changed.


current
![](https://i.gyazo.com/e7f41fe68d4d637f2510882c3032d11a.gif)
fixed(in this commit)
![](https://i.gyazo.com/5a3a8d534bafa0cc818a30cd2da101f6.gif)