### PR TITLE
ensure Transform.removeMark() doesn't try to remove a MarkType

### DIFF
--- a/src/mark.js
+++ b/src/mark.js
@@ -50,7 +50,7 @@ Transform.prototype.removeMark = function(from, to, mark = null) {
     if (mark instanceof MarkType) {
       let set = node.marks, found
       while (found = mark.isInSet(set)) {
-        ;(toRemove || (toRemove = [])).push(mark)
+        ;(toRemove || (toRemove = [])).push(found)
         set = found.removeFromSet(set)
       }
     } else if (mark) {


### PR DESCRIPTION
FIX: Fix an issue where MarkType removal is attempted instead of removing the Mark.

Issue #17

---

the current release (v1.2.10) throws the following error in my application.

```
stack: TypeError: style.eq is not a function
      at /Users/john/code/api/node_modules/prosemirror-transform/dist/index.js:1099
```
https://github.com/ProseMirror/prosemirror-transform/blob/48cf9d348e73b560298763b633204dca54e119db/src/mark.js#L67

```
Mark.eq > function 👍 
MarkType.eq > undefined
```

from the looks of it, this was just a typo. i'm guessing my hack of a test hid it because [i didn't add marks to the document correctly](https://github.com/ProseMirror/prosemirror-transform/blob/48cf9d348e73b560298763b633204dca54e119db/test/test-trans.js#L110-L120).

related: https://github.com/ProseMirror/prosemirror-transform/commit/47cbf5fd886779058dd4a103ec6da588ae29f053#r46805194