### PR TITLE
Expose `StepMap.empty` in documentation

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -139,6 +139,8 @@ export class StepMap {
   }
 }
 
+// :: StepMap
+// A StepMap that contains no changed ranges.
 StepMap.empty = new StepMap([])
 
 // :: class extends Mappable


### PR DESCRIPTION
This was exposed from the `StepMap` constructor in prosemirror-transform 1.3.4. 

However it is not listed in the ProseMirror reference/public API. I would like to add this so it can be added to the DefinitelyTyped type definitions.