### PR TITLE
fix: fix next setNodeMarkup setp rebase fail when pre step is a setNodeMarkup step

### DIFF
--- a/src/step.js
+++ b/src/step.js
@@ -16,6 +16,9 @@ const stepsByID = Object.create(null)
 // JSON-serialization identifier using
 // [`Step.jsonID`](#transform.Step^jsonID).
 export class Step {
+  constructor(changeDocStructure = false) {
+    this.changeDocStructure = changeDocStructure
+  }
   // :: (doc: Node) → StepResult
   // Applies this step to the given document, returning a result
   // object that either indicates failure, if the step can not be

--- a/src/structure.js
+++ b/src/structure.js
@@ -147,16 +147,22 @@ function canChangeType(doc, pos, type) {
 Transform.prototype.setNodeMarkup = function(pos, type, attrs, marks) {
   let node = this.doc.nodeAt(pos)
   if (!node) throw new RangeError("No node at given position")
-  if (!type) type = node.type
+  let notChangeDocStructure = false
+  if (!type) {
+    type = node.type
+    notChangeDocStructure = true
+  } else {
+    notChangeDocStructure = node.type === type
+  }
   let newNode = type.create(attrs, null, marks || node.marks)
   if (node.isLeaf)
-    return this.replaceWith(pos, pos + node.nodeSize, newNode)
+    return this.replaceWith(pos, pos + node.nodeSize, newNode, notChangeDocStructure)
 
   if (!type.validContent(node.content))
     throw new RangeError("Invalid content for node type " + type.name)
 
   return this.step(new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1, pos + node.nodeSize - 1,
-                                         new Slice(Fragment.from(newNode), 0, 0), 1, true))
+                                         new Slice(Fragment.from(newNode), 0, 0), 1, true, notChangeDocStructure))
 }
 
 // :: (Node, number, number, ?[?{type: NodeType, attrs: ?Object}]) → bool


### PR DESCRIPTION
When setNodeMarkup Step just change the attributes or marks of the node, it  will not change the structure, so that time the return value of getMap should be an empty StepMap.