### PR TITLE
Add missing tags to test

### DIFF
--- a/test/test-trans.ts
+++ b/test/test-trans.ts
@@ -97,7 +97,7 @@ describe("Transform", () => {
            doc(p("hello link"))))
 
     it("doesn't remove a non-matching link", () =>
-       rem(doc(p("hello ", a("link"))),
+       rem(doc(p("<a>hello ", a("link<b>"))),
            schema.mark("link", {href: "bar"}),
            doc(p("hello ", a("link")))))
 


### PR DESCRIPTION
This test just happens to pass however it ends up passing `undefined` from the tag lookup into the replace resulting in short-circuiting `nodesBetween`.