### PR TITLE
Use correct parent depth when dropping context

### DIFF
--- a/src/replace.ts
+++ b/src/replace.ts
@@ -373,9 +373,9 @@ export function replaceRange(tr: Transform, from: number, to: number, slice: Sli
     let leftNode = leftNodes[d],
         type = leftNode.type,
         def = definesContent(type),
-        targetDepth = Math.max(Math.abs(preferredTarget) - 1, 0),
-        target = $from.node(targetDepth)
-    if (def && !leftNode.sameMarkup(target)) preferredDepth = d
+        targetDepth = Math.abs(preferredTarget) - 1,
+        parent = $from.node(targetDepth)
+    if (def && !leftNode.sameMarkup(parent)) preferredDepth = d
     else if (def || !type.isTextblock) break
   }
 

--- a/src/replace.ts
+++ b/src/replace.ts
@@ -359,7 +359,7 @@ export function replaceRange(tr: Transform, from: number, to: number, slice: Sli
   // target depth, starting with the preferred depths.
   let preferredTargetIndex = targetDepths.indexOf(preferredTarget)
 
-  let leftNodes = [], preferredDepth = slice.openStart
+  let leftNodes: Node[] = [], preferredDepth = slice.openStart
   for (let content = slice.content, i = 0;; i++) {
     let node = content.firstChild!
     leftNodes.push(node)
@@ -370,8 +370,12 @@ export function replaceRange(tr: Transform, from: number, to: number, slice: Sli
   // Back up preferredDepth to cover defining textblocks directly
   // above it, possibly skipping a non-defining textblock.
   for (let d = preferredDepth - 1; d >= 0; d--) {
-    let type = leftNodes[d].type, def = definesContent(type)
-    if (def && $from.node(preferredTargetIndex).type != type) preferredDepth = d
+    let leftNode = leftNodes[d],
+        type = leftNode.type,
+        def = definesContent(type),
+        targetDepth = Math.max(Math.abs(preferredTarget) - 1, 0),
+        target = $from.node(targetDepth)
+    if (def && !leftNode.sameMarkup(target)) preferredDepth = d
     else if (def || !type.isTextblock) break
   }
 
@@ -443,7 +447,7 @@ export function deleteRange(tr: Transform, from: number, to: number) {
 // Returns an array of all depths for which $from - $to spans the
 // whole content of the nodes at that depth.
 function coveredDepths($from: ResolvedPos, $to: ResolvedPos) {
-  let result = [], minDepth = Math.min($from.depth, $to.depth)
+  let result: number[] = [], minDepth = Math.min($from.depth, $to.depth)
   for (let d = minDepth; d >= 0; d--) {
     let start = $from.start(d)
     if (start < $from.pos - ($from.depth - d) ||

--- a/test/test-trans.ts
+++ b/test/test-trans.ts
@@ -2,7 +2,7 @@ import {schema, doc, blockquote, pre, h1, h2, p, li, ol, ul, em,
         strong, code, a, img, br, hr, eq, builders} from "prosemirror-test-builder"
 import {testTransform} from "./trans.js"
 import {Transform, liftTarget, findWrapping} from "prosemirror-transform"
-import {Slice, Fragment, Schema, Node, Mark, MarkType, NodeType, Attrs} from "prosemirror-model"
+import {Slice, Fragment, Schema, Node, Mark, MarkType, NodeType, Attrs, NodeSpec} from "prosemirror-model"
 import ist from "ist"
 
 function tag$(node: Node, tag: string): number | null {
@@ -801,10 +801,88 @@ describe("Transform", () => {
             doc(ul(li(p("<a>one")), li(p("two<b>")))),
             doc(ul(li(p("one")), li(p("twofoo"))))))
 
+    it("keeps defining context when it doesn't matches the parent markup", () => {
+      let spec: NodeSpec = {
+        content: "block+",
+        group: "block",
+        definingForContent: true,
+        definingAsContext: false,
+        attrs: {
+          color: {
+            default: "black",
+          },
+        },
+        parseDOM: [
+          {
+            tag: "blockquote",
+            getAttrs(node) {
+              const dom = node as HTMLElement;
+              const color = dom.getAttribute("data-color") || "black";
+              return { color };
+            },
+          },
+        ],
+        toDOM(node) {
+          const color = node.attrs.color || "black";
+          return [
+            "blockquote",
+            { "data-color": color, style: `border-left: 5px solid ${color};` },
+            0,
+          ];
+        },
+        toDebugString(node) {
+          let color = node.attrs.color
+          let children: string[] = []
+          node.forEach(child => {
+            children.push(child.toString())
+          })
+          return `blockquote[${color}](${children.join(", ")})`;
+        },
+      };
+      let s = new Schema({
+        nodes: schema.spec.nodes.update("blockquote", spec),
+        marks: schema.spec.marks,
+      });
+      let { b1, b2, b3, b4, b5, b6, p, doc } = builders(s, {
+        b1: { nodeType: "blockquote", color: "#100" },
+        b2: { nodeType: "blockquote", color: "#200" },
+        b3: { nodeType: "blockquote", color: "#300" },
+        b4: { nodeType: "blockquote", color: "#400" },
+        b5: { nodeType: "blockquote", color: "#500" },
+        b6: { nodeType: "blockquote", color: "#600" },
+        p: { nodeType: "paragraph" },
+        doc: { nodeType: "doc" },
+      });
+
+      const source = doc(b1(p("<a>b1")), b2(p("b2<b>")))
+
+      const before1 = [b3(p("b3")), b4(p("<a>"))];
+      const before2 = [b5(p("b5"), ...before1)];
+      const before3 = [b6(p("b6"), ...before2)];
+
+      const expect1 = [b3(p("b3")), b1(p("b1")), b2(p("b2"))];
+      const expect2 = [b5(p("b5"), ...expect1)];
+      const expect3 = [b6(p("b6"), ...expect2)];
+
+      repl(doc(...before1), source, doc(...expect1));
+      repl(doc(...before2), source, doc(...expect2));
+      repl(doc(...before3), source, doc(...expect3))
+    });            
+
     it("drops defining context when it matches the parent structure", () =>
        repl(doc(blockquote(p("<a>"))),
             doc(blockquote(p("<a>one<b>"))),
             doc(blockquote(p("one")))))
+
+    it("drops defining context when it matches the parent structure in a nested context", () =>
+       repl(doc(ul(li(p("list1"), blockquote(p("<a>"))))),
+            doc(blockquote(p("<a>one<b>"))),
+            doc(ul(li(p("list1"), blockquote(p("one")))))));
+
+    it("drops defining context when it matches the parent structure in a deep nested context", () =>
+      repl(doc(ul(li(p("list1"), ul(li(p("list2"), blockquote(p("<a>"))))))),
+           doc(blockquote(p("<a>one<b>"))),
+           doc(ul(li(p("list1"), ul(li(p("list2"), blockquote(p("one")))))))));      
 
     it("closes open nodes at the start", () =>
        repl(doc("<a>", p("abc"), "<b>"),


### PR DESCRIPTION
This pull request addresses two issues in `replaceRange` related to the context being dropped.

The first issue arises when ProseMirror fails to drop the context if the paste target is sufficiently deep. This bug is shown in the following video:

https://github.com/ProseMirror/prosemirror-transform/assets/24715727/a577355b-8b22-4fdb-98e9-65d7342a5cb0

When pasting `<blockquote>one</blockquote>` into an empty `blockquote` that inserts a list item (i.e., Case 2 and Case 3 in the video). The defining context is not dropped as expected, leading to an unexpected nested blockquote structure.

In [this line](https://github.com/ProseMirror/prosemirror-transform/blob/75123e4246857fcdbdc7a1ffba3ce14f3b2dfb6e/src/replace.ts#L374), the defining context is derived from `$from.node(preferredTargetIndex)`. However, it appears that `preferredTargetIndex` is merely an index of various depths, and it doesn't necessarily represent a valid depth. I replaced `preferredTargetIndex` with `Math.abs(preferredTarget) - 1`, following a similar logic [here](https://github.com/ProseMirror/prosemirror-transform/blob/75123e4246857fcdbdc7a1ffba3ce14f3b2dfb6e/src/replace.ts#L386-L387).

---

The second issue is shown in the video below:

https://github.com/ProseMirror/prosemirror-transform/assets/24715727/bc165ecb-06fe-4d2a-851e-8f4e8349ffc7

The source code for this demo can be found [here](https://stackblitz.com/github/issueset/pm-color-blockquote). In this demo, a blockquote node has an attribute to mark its border color.

When copying `red lightblue` and pasting them into a gray blockquote, I expected the gray color to be dropped and replaced by the red color. However, the behavior is inconsistent. If the gray blockquote is inside a nested blockquote (i.e., Case 2 and Case 3), it doesn't get dropped.

I resolved this issue by comparing not only the node types of the incoming node and the existing context, but also their attributes. I replaced `(...).type != type` with `!type.sameMarkup(...)` in [this line](https://github.com/ProseMirror/prosemirror-transform/blob/75123e4246857fcdbdc7a1ffba3ce14f3b2dfb6e/src/replace.ts#L374).

---

I have included the demos from the two videos as test code in this PR. I appreciate your time in reviewing this PR. I acknowledge that I still have a lot to learn and I warmly welcome any corrections. Thank you!