### PR TITLE
Add step for setting document attributes

### DIFF
--- a/src/attr_step.ts
+++ b/src/attr_step.ts
@@ -51,3 +51,48 @@ export class AttrStep extends Step {
 }
 
 Step.jsonID("attr", AttrStep)
+
+/// Update an attribute in the doc node.
+export class DocAttrStep extends Step {
+  /// Construct an attribute step.
+  constructor(
+    /// The attribute to set.
+    readonly attr: string,
+    // The attribute's new value.
+    readonly value: any
+  ) {
+    super()
+  }
+
+  apply(doc: Node) {
+    let attrs = Object.create(null)
+    for (let name in doc.attrs) attrs[name] = doc.attrs[name]
+    attrs[this.attr] = this.value
+    let updated = doc.type.create(attrs, doc.content, doc.marks)
+    return StepResult.ok(updated)
+  }
+
+  getMap() {
+    return StepMap.empty
+  }
+
+  invert(doc: Node) {
+    return new DocAttrStep(this.attr, doc.attrs[this.attr])
+  }
+
+  map(mapping: Mappable) {
+    return this
+  }
+
+  toJSON(): any {
+    return {stepType: "docAttr", attr: this.attr, value: this.value}
+  }
+
+  static fromJSON(schema: Schema, json: any) {
+    if (typeof json.attr != "string")
+      throw new RangeError("Invalid input for DocAttrStep.fromJSON")
+    return new DocAttrStep(json.attr, json.value)
+  }
+}
+
+Step.jsonID("docAttr", DocAttrStep)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -5,7 +5,7 @@ import {Step} from "./step"
 import {addMark, removeMark, clearIncompatible} from "./mark"
 import {replaceStep, replaceRange, replaceRangeWith, deleteRange} from "./replace"
 import {lift, wrap, setBlockType, setNodeMarkup, split, join} from "./structure"
-import {AttrStep} from "./attr_step"
+import {AttrStep, DocAttrStep} from "./attr_step"
 import {AddNodeMarkStep, RemoveNodeMarkStep} from "./mark_step"
 
 /// @internal
@@ -179,8 +179,16 @@ export class Transform {
   }
 
   /// Set a single attribute on a given node to a new value.
+  /// The `pos` addresses the document content. Use `setDocAttribute`
+  /// to set attributes on the document itself.
   setNodeAttribute(pos: number, attr: string, value: any): this {
     this.step(new AttrStep(pos, attr, value))
+    return this
+  }
+
+  /// Set a single attribute on the document to a new value.
+  setDocAttribute(attr: string, value: any): this {
+    this.step(new DocAttrStep(attr, value))
     return this
   }
 

--- a/test/test-trans.ts
+++ b/test/test-trans.ts
@@ -973,4 +973,22 @@ describe("Transform", () => {
     it("sets an attribute", () =>
       set(doc("<a>", h1("a")), "level", 2, doc("<a>", h2("a"))))
   })
+
+  describe("setDocAttribute", () => {
+    let schema = new Schema({
+      nodes: {doc: {content: "text*", attrs: {meta: {default: null}}},
+              text: {}},
+    })
+
+    let {doc} = builders(schema, {
+      doc: {nodeType: "doc"}
+    })
+
+    function set(doc: Node, attr: string, value: any, expect: Node) {
+      testTransform(new Transform(doc).setDocAttribute(attr, value), expect)
+    }
+
+    it("sets an attribute", () =>
+      set(doc(), "meta", "hello", doc({meta: "hello"})))
+  })
 })


### PR DESCRIPTION
Based on [discussion thread](https://discuss.prosemirror.net/t/changing-doc-attrs/784/28)

Adds a new step type `DocAttrStep` and the related transform method `setDocAttribute`.