### PR TITLE
Fix ReplaceAroundStep mapping when its from is zero

### DIFF
--- a/src/replace_step.ts
+++ b/src/replace_step.ts
@@ -134,7 +134,14 @@ export class ReplaceAroundStep extends Step {
 
   map(mapping: Mappable) {
     let from = mapping.mapResult(this.from, 1), to = mapping.mapResult(this.to, -1)
-    let gapFrom = mapping.map(this.gapFrom, 1), gapTo = mapping.map(this.gapTo, -1)
+    let gapFrom: number, gapTo: number
+    if (this.gapFrom == this.from && this.gapTo == this.to) {
+      gapFrom = mapping.map(this.gapFrom, 1)
+      gapTo = mapping.map(this.gapTo, -1)
+    } else {
+      gapFrom = mapping.map(this.gapFrom, -1)
+      gapTo = mapping.map(this.gapTo, 1)
+    }
     if ((from.deletedAcross && to.deletedAcross) || gapFrom < from.pos || gapTo > to.pos) return null
     return new ReplaceAroundStep(from.pos, to.pos, gapFrom, gapTo, this.slice, this.insert, this.structure)
   }

--- a/src/replace_step.ts
+++ b/src/replace_step.ts
@@ -134,7 +134,7 @@ export class ReplaceAroundStep extends Step {
 
   map(mapping: Mappable) {
     let from = mapping.mapResult(this.from, 1), to = mapping.mapResult(this.to, -1)
-    let gapFrom = mapping.map(this.gapFrom, -1), gapTo = mapping.map(this.gapTo, 1)
+    let gapFrom = mapping.map(this.gapFrom, 1), gapTo = mapping.map(this.gapTo, -1)
     if ((from.deletedAcross && to.deletedAcross) || gapFrom < from.pos || gapTo > to.pos) return null
     return new ReplaceAroundStep(from.pos, to.pos, gapFrom, gapTo, this.slice, this.insert, this.structure)
   }

--- a/test/test-replace_step.ts
+++ b/test/test-replace_step.ts
@@ -5,7 +5,8 @@ import { ReplaceAroundStep, StepMap } from "prosemirror-transform";
 
 describe("ReplaceAroundStep", () => {
   it("can map if its from is positive", () => {
-    let slice = new Slice(Fragment.from(blockquote(p())), 0, 0);
+    let slice = new Slice(Fragment.from(blockquote()), 0, 0);
+    // Wrap the content between 10 and 20 in a blockquote
     let step = new ReplaceAroundStep(10, 20, 10, 20, slice, 1, true);
     let mappedStep = step.map(StepMap.offset(100));
     ist(mappedStep?.from, 110);
@@ -15,7 +16,8 @@ describe("ReplaceAroundStep", () => {
   });
 
   it("can map if its from is 0", () => {
-    let slice = new Slice(Fragment.from(blockquote(p())), 0, 0);
+    let slice = new Slice(Fragment.from(blockquote()), 0, 0);
+    // Wrap the content between 0 and 20 in a blockquote
     let step = new ReplaceAroundStep(0, 20, 0, 20, slice, 1, true);
     let mappedStep = step.map(StepMap.offset(100));
     ist(mappedStep?.from, 100);

--- a/test/test-replace_step.ts
+++ b/test/test-replace_step.ts
@@ -1,0 +1,26 @@
+import ist from "ist";
+import { Fragment, Slice } from "prosemirror-model";
+import { blockquote, p } from "prosemirror-test-builder";
+import { ReplaceAroundStep, StepMap } from "prosemirror-transform";
+
+describe("ReplaceAroundStep", () => {
+  it("can map if its from is positive", () => {
+    let slice = new Slice(Fragment.from(blockquote(p())), 0, 0);
+    let step = new ReplaceAroundStep(10, 20, 10, 20, slice, 1, true);
+    let mappedStep = step.map(StepMap.offset(100));
+    ist(mappedStep?.from, 110);
+    ist(mappedStep?.to, 120);
+    ist(mappedStep?.gapFrom, 110);
+    ist(mappedStep?.gapTo, 120);
+  });
+
+  it("can map if its from is 0", () => {
+    let slice = new Slice(Fragment.from(blockquote(p())), 0, 0);
+    let step = new ReplaceAroundStep(0, 20, 0, 20, slice, 1, true);
+    let mappedStep = step.map(StepMap.offset(100));
+    ist(mappedStep?.from, 100);
+    ist(mappedStep?.to, 120);
+    ist(mappedStep?.gapFrom, 100);
+    ist(mappedStep?.gapTo, 120);
+  });
+});


### PR DESCRIPTION
This PR fixes a bug where `step.map(StepMap.offset(100))` returns `null` unexpectedly if `step` is a `ReplaceAroundStep` instance and `step.from` is `0`.

I added two tests to this PR. Only the first test can pass before the patch, and both tests can pass after the patch. 