### PR TITLE
dont mutate maps or mirror

### DIFF
--- a/src/map.ts
+++ b/src/map.ts
@@ -173,9 +173,9 @@ export class Mapping implements Mappable {
   /// Create a new mapping with the given position maps.
   constructor(
     /// The step maps in this mapping.
-    readonly maps: StepMap[] = [],
+    public maps: readonly StepMap[] = [],
     /// @internal
-    public mirror?: number[],
+    public mirror?: readonly number[],
     /// The starting position in the `maps` array, used when `map` or
     /// `mapResult` is called.
     public from = 0,
@@ -197,7 +197,8 @@ export class Mapping implements Mappable {
   /// given, it should be the index of the step map that is the mirror
   /// image of this one.
   appendMap(map: StepMap, mirrors?: number) {
-    this.to = this.maps.push(map)
+    this.maps = this.maps.concat(map)
+    this.to = this.maps.length
     if (mirrors != null) this.setMirror(this.maps.length - 1, mirrors)
   }
 
@@ -221,7 +222,7 @@ export class Mapping implements Mappable {
   /// @internal
   setMirror(n: number, m: number) {
     if (!this.mirror) this.mirror = []
-    this.mirror.push(n, m)
+    this.mirror = this.mirror.concat(n, m)
   }
 
   /// Append the inverse of the given mapping to this one.


### PR DESCRIPTION
Was [reverting tracked changes](https://github.com/ProseMirror/website/blob/09f795d07f3717f2041a9936df4f052b381f90aa/example/track/index.js#L257) and noticed that `appendMap` mutates the original array passed into `new Mapping`. Doesn't happen in the example code but happened in my codebase where I didn't defensively clone the maps array.