### PR TITLE
Update replace.ts (replaceRange) to use already defined $to

### DIFF
--- a/src/replace.ts
+++ b/src/replace.ts
@@ -338,7 +338,7 @@ export function replaceRange(tr: Transform, from: number, to: number, slice: Sli
   if (fitsTrivially($from, $to, slice))
     return tr.step(new ReplaceStep(from, to, slice))
 
-  let targetDepths = coveredDepths($from, tr.doc.resolve(to))
+  let targetDepths = coveredDepths($from, $to)
   // Can't replace the whole document, so remove 0 if it's present
   if (targetDepths[targetDepths.length - 1] == 0) targetDepths.pop()
   // Negative numbers represent not expansion over the whole node at


### PR DESCRIPTION
A simple change to use the already defined `$to = tr.doc.resolve(to)` variable instead of recreating the ResolvePos